### PR TITLE
fix (content-type) : files are now uploaded with content-type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ hs_err_pid*
 
 target/
 out/
+
+# JetBrains files
+.idea
+*.iml

--- a/awsS3Plugin-agent/pom.xml
+++ b/awsS3Plugin-agent/pom.xml
@@ -20,6 +20,13 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.apache.tika</groupId>
+            <artifactId>tika-core</artifactId>
+            <version>1.22</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.dcn.teamcity.awsS3Plugin</groupId>
             <artifactId>awsS3Plugin-common</artifactId>
             <version>0.1.1</version>

--- a/awsS3Plugin-agent/src/main/java/com/dcn/teamcity/awsS3Plugin/adapters/AWSS3UploadAdapter.java
+++ b/awsS3Plugin-agent/src/main/java/com/dcn/teamcity/awsS3Plugin/adapters/AWSS3UploadAdapter.java
@@ -6,16 +6,17 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import jetbrains.buildServer.log.Loggers;
 import jetbrains.buildServer.util.StringUtil;
+import org.apache.tika.Tika;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 /**
  * @author <a href="mailto:gonzalo.docarmo@gmail.com">Gonzalo G. do Carmo Norte</a>
  */
 public class AWSS3UploadAdapter {
+
+    private final Tika tika = new Tika();
 
     public void uploadToBucket(String bucketName, AmazonS3 s3Client, File file, String destinationDir, String cacheControlString) throws AmazonClientException {
         String key = StringUtil.nullIfEmpty(destinationDir) == null ? file.getName() : destinationDir + "/" + file.getName();
@@ -32,12 +33,11 @@ public class AWSS3UploadAdapter {
     private ObjectMetadata buildMetadata(File file, String cacheControlString) {
         final ObjectMetadata objectMetadata = new ObjectMetadata();
 
-        final Path filePath = file.toPath();
         try {
-            final String contentType = Files.probeContentType(filePath);
+            final String contentType = tika.detect(file);
             objectMetadata.setContentType(contentType);
         } catch (IOException e) {
-            Loggers.SERVER.warn("Unable to get content type for file " + filePath, e);
+            Loggers.SERVER.warn("Unable to get content type for file " + file.getPath(), e);
         }
 
         if (cacheControlString != null) {

--- a/awsS3Plugin-agent/src/test/java/com/dcn/teamcity/awsS3Plugin/adapters/AWSS3UploadAdapterTest.java
+++ b/awsS3Plugin-agent/src/test/java/com/dcn/teamcity/awsS3Plugin/adapters/AWSS3UploadAdapterTest.java
@@ -1,6 +1,7 @@
 package com.dcn.teamcity.awsS3Plugin.adapters;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeMethod;
@@ -8,8 +9,7 @@ import org.testng.annotations.Test;
 
 import java.io.File;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -45,7 +45,12 @@ public class AWSS3UploadAdapterTest {
         assertEquals(bucketName, argument.getValue().getBucketName());
         assertEquals(source.getName(), argument.getValue().getKey());
         assertEquals(source, argument.getValue().getFile());
-        assertNull(argument.getValue().getMetadata());
+        final PutObjectRequest request = argument.getValue();
+        assertNotNull(request);
+        final ObjectMetadata metadata = request.getMetadata();
+        assertNotNull(metadata);
+        assertNotNull(metadata.getContentType());
+        assertNull(metadata.getCacheControl());
     }
 
     @Test
@@ -60,7 +65,12 @@ public class AWSS3UploadAdapterTest {
         assertEquals(bucketName, argument.getValue().getBucketName());
         assertEquals(source.getName(), argument.getValue().getKey());
         assertEquals(source, argument.getValue().getFile());
-        assertNull(argument.getValue().getMetadata());
+        final PutObjectRequest request = argument.getValue();
+        assertNotNull(request);
+        final ObjectMetadata metadata = request.getMetadata();
+        assertNotNull(metadata);
+        assertNotNull(metadata.getContentType());
+        assertNull(metadata.getCacheControl());
     }
 
     @Test
@@ -75,7 +85,12 @@ public class AWSS3UploadAdapterTest {
         assertEquals(bucketName, argument.getValue().getBucketName());
         assertEquals(destinationDir + "/" + source.getName(), argument.getValue().getKey());
         assertEquals(source, argument.getValue().getFile());
-        assertNull(argument.getValue().getMetadata());
+        final PutObjectRequest request = argument.getValue();
+        assertNotNull(request);
+        final ObjectMetadata metadata = request.getMetadata();
+        assertNotNull(metadata);
+        assertNotNull(metadata.getContentType());
+        assertNull(metadata.getCacheControl());
     }
 
     @Test

--- a/awsS3Plugin-agent/src/test/java/com/dcn/teamcity/awsS3Plugin/adapters/AWSS3UploadAdapterTest.java
+++ b/awsS3Plugin-agent/src/test/java/com/dcn/teamcity/awsS3Plugin/adapters/AWSS3UploadAdapterTest.java
@@ -4,11 +4,12 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import org.mockito.ArgumentCaptor;
-import org.springframework.util.MimeTypeUtils;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.attribute.PosixFilePermissions;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
@@ -129,8 +130,9 @@ public class AWSS3UploadAdapterTest {
     }
 
     @Test
-    public void testUploadToBucketWhenContentTypeUnDetected() throws Exception {
+    public void testUploadToBucketWhenContentTypeThrowsIOException() throws Exception {
         final File source = File.createTempFile("temp", ".bla");
+        Files.setPosixFilePermissions(source.toPath(), PosixFilePermissions.fromString("---------"));
         final String destinationDir = "src/here";
 
         adapter.uploadToBucket(bucketName, amazonS3Client, source, destinationDir, httpHeaderCacheControl);

--- a/build/build.iml
+++ b/build/build.iml
@@ -9,6 +9,7 @@
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="module" module-name="agent" />
+    <orderEntry type="library" name="Maven: org.apache.tika:tika-core:1.22" level="project" />
     <orderEntry type="library" name="Maven: com.amazonaws:aws-java-sdk-s3:1.11.15" level="project" />
     <orderEntry type="library" name="Maven: com.amazonaws:aws-java-sdk-kms:1.11.15" level="project" />
     <orderEntry type="library" name="Maven: com.amazonaws:aws-java-sdk-core:1.11.15" level="project" />


### PR DESCRIPTION
By default, content-type is "binary/octet-stream". On web applications, when accessing a text file with a "binary/octet-stream" instead of "text/plain" content-type, most browsers/clients download files instead of display it.